### PR TITLE
Improve website-list empty/search states + fix README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple Website Blocker
 
-[![build](https://github.com/marcuiulian13/chrome-extension-simple-website-blocker/actions/workflows/build.yml/badge.svg)](https://github.com/marcuiulian13/chrome-extension-simple-website-blocker/actions/workflows/build.yml)
+[![Build and Test](https://github.com/iuliancmarcu/chrome-extension-simple-website-blocker/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/iuliancmarcu/chrome-extension-simple-website-blocker/actions/workflows/build-and-test.yml)
 
 A simple Chrome extension to block distracting websites and regain control of your focus, improving productivity and time management.
 

--- a/src/components/organism/WebsiteList.test.tsx
+++ b/src/components/organism/WebsiteList.test.tsx
@@ -35,10 +35,18 @@ describe('WebsiteList', () => {
     expect(inputs[1]).toHaveValue('reddit.com');
   });
 
-  it('shows an empty state when there are no websites', () => {
+  it('prompts for a first website and disables search when empty', () => {
     renderWebsiteList([]);
 
-    expect(screen.getByText('No websites found.')).toBeInTheDocument();
+    expect(screen.getByText(/add your first website/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search...')).toBeDisabled();
+    expect(screen.queryByText('No websites found.')).not.toBeInTheDocument();
+  });
+
+  it('keeps the add button available when the list is empty', () => {
+    renderWebsiteList([]);
+
+    expect(screen.getByTitle('Add new website')).toBeInTheDocument();
   });
 
   it('prepends an empty row when the add button is clicked', async () => {
@@ -52,14 +60,14 @@ describe('WebsiteList', () => {
     expect(inputs[1]).toHaveValue('x.com');
   });
 
-  it('removes a row when its remove icon is clicked', async () => {
+  it('removes a row and returns to the empty prompt', async () => {
     renderWebsiteList([{ address: 'x.com' }]);
 
     expect(removeIcons()).toHaveLength(1);
     await userEvent.click(removeIcons()[0]);
 
     expect(screen.queryByDisplayValue('x.com')).not.toBeInTheDocument();
-    expect(screen.getByText('No websites found.')).toBeInTheDocument();
+    expect(screen.getByText(/add your first website/i)).toBeInTheDocument();
   });
 
   it('filters the list by the search query', async () => {
@@ -69,6 +77,26 @@ describe('WebsiteList', () => {
 
     expect(screen.getByDisplayValue('reddit.com')).toBeInTheDocument();
     expect(screen.queryByDisplayValue('x.com')).not.toBeInTheDocument();
+  });
+
+  it('shows "No websites found." only when a search matches nothing', async () => {
+    renderWebsiteList([{ address: 'x.com' }]);
+
+    await userEvent.type(screen.getByPlaceholderText('Search...'), 'zzz');
+
+    expect(screen.getByText('No websites found.')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/add your first website/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the add button while searching', async () => {
+    renderWebsiteList([{ address: 'x.com' }]);
+    expect(screen.getByTitle('Add new website')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByPlaceholderText('Search...'), 'x');
+
+    expect(screen.queryByTitle('Add new website')).not.toBeInTheDocument();
   });
 
   it('normalizes a pasted URL to a bare domain on blur', async () => {

--- a/src/components/organism/WebsiteList.tsx
+++ b/src/components/organism/WebsiteList.tsx
@@ -31,6 +31,10 @@ export function WebsiteList({ className }: IWebsiteList) {
 
   const [search, setSearch] = useState<string>('');
 
+  const isEmpty = fields.length === 0;
+  const isSearching = search.length > 0;
+  const hasMatches = fields.some(field => field.address.includes(search));
+
   return (
     <div className={className}>
       <OptionsTitle
@@ -39,8 +43,9 @@ export function WebsiteList({ className }: IWebsiteList) {
       />
       <div className="mb-2 flex items-center gap-2">
         <TextInput
-          className="w-full"
+          className="w-full disabled:cursor-not-allowed disabled:opacity-60"
           value={search}
+          disabled={isEmpty}
           placeholder="Search..."
           iconLeft={<FaSearch />}
           iconRight={
@@ -50,19 +55,26 @@ export function WebsiteList({ className }: IWebsiteList) {
           }
           onChange={e => setSearch(e.target.value.toLowerCase().trim())}
         />
-        <Button
-          className="px-2"
-          type="button"
-          title="Add new website"
-          onClick={() => prepend({ address: '' }, { shouldFocus: true })}
-        >
-          <div className="flex items-center gap-1">
-            <FaPlus />
-          </div>
-        </Button>
+        {!isSearching && (
+          <Button
+            className="px-2"
+            type="button"
+            title="Add new website"
+            onClick={() => prepend({ address: '' }, { shouldFocus: true })}
+          >
+            <div className="flex items-center gap-1">
+              <FaPlus />
+            </div>
+          </Button>
+        )}
       </div>
       <div className="-m-1 flex max-h-56 flex-col items-center gap-1 overflow-y-scroll p-1">
-        {!fields.some(field => field.address.includes(search)) && (
+        {isEmpty && (
+          <p className="text-gray-500">
+            Add your first website using the “+” button.
+          </p>
+        )}
+        {!isEmpty && isSearching && !hasMatches && (
           <p className="text-gray-500">No websites found.</p>
         )}
         {fields.map((field, index) => {


### PR DESCRIPTION
Follow-up UX polish on the blocked-websites list, plus a README badge fix.

## Website list
- **Empty list:** the search box is now disabled and shows **"Add your first website using the +" ** prompt, instead of the misleading "No websites found.".
- **"No websites found."** now appears **only during an active search** that matches nothing.
- **Add (+) button is hidden while searching**, so it's clear the box is filtering, not adding. It returns (and stays available, including on an empty list) when the search is cleared.

All driven by `fields.length` (empty) and whether the search box has text.

## README
Fixed the build badge — it pointed at the old `build.yml` workflow and a stale repo owner; now references `build-and-test.yml` under the correct owner.

## Verification
`npm test` (68, +3 new WebsiteList cases) · `tsc --noEmit` clean · ESLint clean · `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)